### PR TITLE
Updating the download URL for geofabrik.de partial planet exports

### DIFF
--- a/counties-01-alabama.sh
+++ b/counties-01-alabama.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/01/w out/01/e
 
-curl -Rs -o tmp/alabama.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/alabama.osm.pbf
+curl -Rs -o tmp/alabama.osm.pbf -L http://download.geofabrik.de/north-america/us/alabama-latest.osm.pbf
 
 osmosis --rb tmp/alabama.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-04-arizona.sh
+++ b/counties-04-arizona.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/04/w out/04/c out/04/e
 
-curl -Rs -o tmp/arizona.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/arizona.osm.pbf
+curl -Rs -o tmp/arizona.osm.pbf -L http://download.geofabrik.de/north-america/us/arizona-latest.osm.pbf
 
 osmosis --rb tmp/arizona.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-05-arkansas.sh
+++ b/counties-05-arkansas.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/05/n out/05/s
 
-curl -Rs -o tmp/arkansas.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/arkansas.osm.pbf
+curl -Rs -o tmp/arkansas.osm.pbf -L http://download.geofabrik.de/north-america/us/arkansas-latest.osm.pbf
 
 osmosis --rb tmp/arkansas.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-06-california.sh
+++ b/counties-06-california.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/06/i out/06/ii out/06/iii out/06/iv out/06/v out/06/vi
 
-curl -Rs -o tmp/california.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/california.osm.pbf
+curl -Rs -o tmp/california.osm.pbf -L http://download.geofabrik.de/north-america/us/california-latest.osm.pbf
 
 osmosis --rb tmp/california.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-08-colorado.sh
+++ b/counties-08-colorado.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/08/n out/08/c out/08/s
 
-curl -Rs -o tmp/colorado.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/colorado.osm.pbf
+curl -Rs -o tmp/colorado.osm.pbf -L http://download.geofabrik.de/north-america/us/colorado-latest.osm.pbf
 
 osmosis --rb tmp/colorado.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-09-connecticut.sh
+++ b/counties-09-connecticut.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/09
 
-curl -Rs -o tmp/connecticut.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/connecticut.osm.pbf
+curl -Rs -o tmp/connecticut.osm.pbf -L http://download.geofabrik.de/north-america/us/connecticut-latest.osm.pbf
 
 osmosis --rb tmp/connecticut.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-10-delaware.sh
+++ b/counties-10-delaware.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/10
 
-curl -Rs -o tmp/delaware.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/delaware.osm.pbf
+curl -Rs -o tmp/delaware.osm.pbf -L http://download.geofabrik.de/north-america/us/delaware-latest.osm.pbf
 
 osmosis --rb tmp/delaware.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-11-district-of-columbia.sh
+++ b/counties-11-district-of-columbia.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/11
 
-curl -Rs -o tmp/district-of-columbia.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/district-of-columbia.osm.pbf
+curl -Rs -o tmp/district-of-columbia.osm.pbf -L http://download.geofabrik.de/north-america/us/district-of-columbia-latest.osm.pbf
 
 osmosis --rb tmp/district-of-columbia.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-12-florida.sh
+++ b/counties-12-florida.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/12/n out/12/w out/12/e
 
-curl -Rs -o tmp/florida.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/florida.osm.pbf
+curl -Rs -o tmp/florida.osm.pbf -L http://download.geofabrik.de/north-america/us/florida-latest.osm.pbf
 
 osmosis --rb tmp/florida.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-13-georgia.sh
+++ b/counties-13-georgia.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/13/w out/13/e
 
-curl -Rs -o tmp/georgia.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/georgia.osm.pbf
+curl -Rs -o tmp/georgia.osm.pbf -L http://download.geofabrik.de/north-america/us/georgia-latest.osm.pbf
 
 osmosis --rb tmp/georgia.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-16-idaho.sh
+++ b/counties-16-idaho.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/16/w out/16/c out/16/e
 
-curl -Rs -o tmp/idaho.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/idaho.osm.pbf
+curl -Rs -o tmp/idaho.osm.pbf -L http://download.geofabrik.de/north-america/us/idaho-latest.osm.pbf
 
 osmosis --rb tmp/idaho.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-17-illinois.sh
+++ b/counties-17-illinois.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/17/w out/17/e
 
-curl -Rs -o tmp/illinois.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/illinois.osm.pbf
+curl -Rs -o tmp/illinois.osm.pbf -L http://download.geofabrik.de/north-america/us/illinois-latest.osm.pbf
 
 osmosis --rb tmp/illinois.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-18-indiana.sh
+++ b/counties-18-indiana.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/18/w out/18/e
 
-curl -Rs -o tmp/indiana.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/indiana.osm.pbf
+curl -Rs -o tmp/indiana.osm.pbf -L http://download.geofabrik.de/north-america/us/indiana-latest.osm.pbf
 
 osmosis --rb tmp/indiana.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-19-iowa.sh
+++ b/counties-19-iowa.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/19/n out/19/s
 
-curl -Rs -o tmp/iowa.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/iowa.osm.pbf
+curl -Rs -o tmp/iowa.osm.pbf -L http://download.geofabrik.de/north-america/us/iowa-latest.osm.pbf
 
 osmosis --rb tmp/iowa.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-20-kansas.sh
+++ b/counties-20-kansas.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/20/n out/20/s
 
-curl -Rs -o tmp/kansas.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/kansas.osm.pbf
+curl -Rs -o tmp/kansas.osm.pbf -L http://download.geofabrik.de/north-america/us/kansas-latest.osm.pbf
 
 osmosis --rb tmp/kansas.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-21-kentucky.sh
+++ b/counties-21-kentucky.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/21/n out/21/s
 
-curl -Rs -o tmp/kentucky.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/kentucky.osm.pbf
+curl -Rs -o tmp/kentucky.osm.pbf -L http://download.geofabrik.de/north-america/us/kentucky-latest.osm.pbf
 
 osmosis --rb tmp/kentucky.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-22-louisiana.sh
+++ b/counties-22-louisiana.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/22/n out/22/s
 
-curl -Rs -o tmp/louisiana.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/louisiana.osm.pbf
+curl -Rs -o tmp/louisiana.osm.pbf -L http://download.geofabrik.de/north-america/us/louisiana-latest.osm.pbf
 
 osmosis --rb tmp/louisiana.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-23-maine.sh
+++ b/counties-23-maine.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/23/w out/23/e
 
-curl -Rs -o tmp/maine.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/maine.osm.pbf
+curl -Rs -o tmp/maine.osm.pbf -L http://download.geofabrik.de/north-america/us/maine-latest.osm.pbf
 
 osmosis --rb tmp/maine.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-24-maryland.sh
+++ b/counties-24-maryland.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/24
 
-curl -Rs -o tmp/maryland.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/maryland.osm.pbf
+curl -Rs -o tmp/maryland.osm.pbf -L http://download.geofabrik.de/north-america/us/maryland-latest.osm.pbf
 
 osmosis --rb tmp/maryland.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-25-massachusetts.sh
+++ b/counties-25-massachusetts.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/25/m out/25/i
 
-curl -Rs -o tmp/massachusetts.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/massachusetts.osm.pbf
+curl -Rs -o tmp/massachusetts.osm.pbf -L http://download.geofabrik.de/north-america/us/massachusetts-latest.osm.pbf
 
 osmosis --rb tmp/massachusetts.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-26-michigan.sh
+++ b/counties-26-michigan.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/26/n out/26/c out/26/s
 
-curl -Rs -o tmp/michigan.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/michigan.osm.pbf
+curl -Rs -o tmp/michigan.osm.pbf -L http://download.geofabrik.de/north-america/us/michigan-latest.osm.pbf
 
 osmosis --rb tmp/michigan.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-27-minnesota.sh
+++ b/counties-27-minnesota.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/27/n out/27/c out/27/s
 
-curl -Rs -o tmp/minnesota.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/minnesota.osm.pbf
+curl -Rs -o tmp/minnesota.osm.pbf -L http://download.geofabrik.de/north-america/us/minnesota-latest.osm.pbf
 
 osmosis --rb tmp/minnesota.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-28-mississippi.sh
+++ b/counties-28-mississippi.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/28/w out/28/e
 
-curl -Rs -o tmp/mississippi.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/mississippi.osm.pbf
+curl -Rs -o tmp/mississippi.osm.pbf -L http://download.geofabrik.de/north-america/us/mississippi-latest.osm.pbf
 
 osmosis --rb tmp/mississippi.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-29-missouri.sh
+++ b/counties-29-missouri.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/29/w out/29/c out/29/e
 
-curl -Rs -o tmp/missouri.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/missouri.osm.pbf
+curl -Rs -o tmp/missouri.osm.pbf -L http://download.geofabrik.de/north-america/us/missouri-latest.osm.pbf
 
 osmosis --rb tmp/missouri.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-30-montana.sh
+++ b/counties-30-montana.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/30/n out/30/c out/30/s
 
-curl -Rs -o tmp/montana.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/montana.osm.pbf
+curl -Rs -o tmp/montana.osm.pbf -L http://download.geofabrik.de/north-america/us/montana-latest.osm.pbf
 
 osmosis --rb tmp/montana.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-31-nebraska.sh
+++ b/counties-31-nebraska.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/31/n out/31/s
 
-curl -Rs -o tmp/nebraska.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/nebraska.osm.pbf
+curl -Rs -o tmp/nebraska.osm.pbf -L http://download.geofabrik.de/north-america/us/nebraska-latest.osm.pbf
 
 osmosis --rb tmp/nebraska.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-32-nevada.sh
+++ b/counties-32-nevada.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/32/w out/32/c out/32/e
 
-curl -Rs -o tmp/nevada.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/nevada.osm.pbf
+curl -Rs -o tmp/nevada.osm.pbf -L http://download.geofabrik.de/north-america/us/nevada-latest.osm.pbf
 
 osmosis --rb tmp/nevada.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-33-new-hampshire.sh
+++ b/counties-33-new-hampshire.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/33
 
-curl -Rs -o tmp/new-hampshire.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/new-hampshire.osm.pbf
+curl -Rs -o tmp/new-hampshire.osm.pbf -L http://download.geofabrik.de/north-america/us/new-hampshire-latest.osm.pbf
 
 osmosis --rb tmp/new-hampshire.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-34-new-jersey.sh
+++ b/counties-34-new-jersey.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/34
 
-curl -Rs -o tmp/new-jersey.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/new-jersey.osm.pbf
+curl -Rs -o tmp/new-jersey.osm.pbf -L http://download.geofabrik.de/north-america/us/new-jersey-latest.osm.pbf
 
 osmosis --rb tmp/new-jersey.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-35-new-mexico.sh
+++ b/counties-35-new-mexico.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/35/w out/35/c out/35/e
 
-curl -Rs -o tmp/new-mexico.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/new-mexico.osm.pbf
+curl -Rs -o tmp/new-mexico.osm.pbf -L http://download.geofabrik.de/north-america/us/new-mexico-latest.osm.pbf
 
 osmosis --rb tmp/new-mexico.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-36-new-york.sh
+++ b/counties-36-new-york.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/36/w out/36/c out/36/e out/36/li
 
-curl -Rs -o tmp/new-york.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/new-york.osm.pbf
+curl -Rs -o tmp/new-york.osm.pbf -L http://download.geofabrik.de/north-america/us/new-york-latest.osm.pbf
 
 osmosis --rb tmp/new-york.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-37-north-carolina.sh
+++ b/counties-37-north-carolina.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/37
 
-curl -Rs -o tmp/north-carolina.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/north-carolina.osm.pbf
+curl -Rs -o tmp/north-carolina.osm.pbf -L http://download.geofabrik.de/north-america/us/north-carolina-latest.osm.pbf
 
 osmosis --rb tmp/north-carolina.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-38-north-dakota.sh
+++ b/counties-38-north-dakota.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/38/n out/38/s
 
-curl -Rs -o tmp/north-dakota.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/north-dakota.osm.pbf
+curl -Rs -o tmp/north-dakota.osm.pbf -L http://download.geofabrik.de/north-america/us/north-dakota-latest.osm.pbf
 
 osmosis --rb tmp/north-dakota.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-39-ohio.sh
+++ b/counties-39-ohio.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/39/n out/39/s
 
-curl -Rs -o tmp/ohio.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/ohio.osm.pbf
+curl -Rs -o tmp/ohio.osm.pbf -L http://download.geofabrik.de/north-america/us/ohio-latest.osm.pbf
 
 osmosis --rb tmp/ohio.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-40-oklahoma.sh
+++ b/counties-40-oklahoma.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/40/n out/40/s
 
-curl -Rs -o tmp/oklahoma.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/oklahoma.osm.pbf
+curl -Rs -o tmp/oklahoma.osm.pbf -L http://download.geofabrik.de/north-america/us/oklahoma-latest.osm.pbf
 
 osmosis --rb tmp/oklahoma.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-41-oregon.sh
+++ b/counties-41-oregon.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/41/n out/41/s
 
-curl -Rs -o tmp/oregon.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/oregon.osm.pbf
+curl -Rs -o tmp/oregon.osm.pbf -L http://download.geofabrik.de/north-america/us/oregon-latest.osm.pbf
 
 osmosis --rb tmp/oregon.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-42-pennsylvania.sh
+++ b/counties-42-pennsylvania.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/42/n out/42/s
 
-curl -Rs -o tmp/pennsylvania.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/pennsylvania.osm.pbf
+curl -Rs -o tmp/pennsylvania.osm.pbf -L http://download.geofabrik.de/north-america/us/pennsylvania-latest.osm.pbf
 
 osmosis --rb tmp/pennsylvania.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-44-rhode-island.sh
+++ b/counties-44-rhode-island.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/44
 
-curl -Rs -o tmp/rhode-island.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/rhode-island.osm.pbf
+curl -Rs -o tmp/rhode-island.osm.pbf -L http://download.geofabrik.de/north-america/us/rhode-island-latest.osm.pbf
 
 osmosis --rb tmp/rhode-island.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-45-south-carolina.sh
+++ b/counties-45-south-carolina.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/45/n out/45/s
 
-curl -Rs -o tmp/south-carolina.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/south-carolina.osm.pbf
+curl -Rs -o tmp/south-carolina.osm.pbf -L http://download.geofabrik.de/north-america/us/south-carolina-latest.osm.pbf
 
 osmosis --rb tmp/south-carolina.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-46-south-dakota.sh
+++ b/counties-46-south-dakota.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/46/n out/46/s
 
-curl -Rs -o tmp/south-dakota.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/south-dakota.osm.pbf
+curl -Rs -o tmp/south-dakota.osm.pbf -L http://download.geofabrik.de/north-america/us/south-dakota-latest.osm.pbf
 
 osmosis --rb tmp/south-dakota.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-47-tennessee.sh
+++ b/counties-47-tennessee.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/47
 
-curl -Rs -o tmp/tennessee.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/tennessee.osm.pbf
+curl -Rs -o tmp/tennessee.osm.pbf -L http://download.geofabrik.de/north-america/us/tennessee-latest.osm.pbf
 
 osmosis --rb tmp/tennessee.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-48-texas.sh
+++ b/counties-48-texas.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/48/n out/48/nc out/48/c out/48/sc out/48/s
 
-curl -Rs -o tmp/texas.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/texas.osm.pbf
+curl -Rs -o tmp/texas.osm.pbf -L http://download.geofabrik.de/north-america/us/texas-latest.osm.pbf
 
 osmosis --rb tmp/texas.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-49-utah.sh
+++ b/counties-49-utah.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/49/n out/49/c out/49/s
 
-curl -Rs -o tmp/utah.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/utah.osm.pbf
+curl -Rs -o tmp/utah.osm.pbf -L http://download.geofabrik.de/north-america/us/utah-latest.osm.pbf
 
 osmosis --rb tmp/utah.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-50-vermont.sh
+++ b/counties-50-vermont.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/50
 
-curl -Rs -o tmp/vermont.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/vermont.osm.pbf
+curl -Rs -o tmp/vermont.osm.pbf -L http://download.geofabrik.de/north-america/us/vermont-latest.osm.pbf
 
 osmosis --rb tmp/vermont.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-51-virginia.sh
+++ b/counties-51-virginia.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/51/n out/51/s
 
-curl -Rs -o tmp/virginia.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/virginia.osm.pbf
+curl -Rs -o tmp/virginia.osm.pbf -L http://download.geofabrik.de/north-america/us/virginia-latest.osm.pbf
 
 osmosis --rb tmp/virginia.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-53-washington.sh
+++ b/counties-53-washington.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/53/n out/53/s
 
-curl -Rs -o tmp/washington.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/washington.osm.pbf
+curl -Rs -o tmp/washington.osm.pbf -L http://download.geofabrik.de/north-america/us/washington-latest.osm.pbf
 
 osmosis --rb tmp/washington.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-54-west-virginia.sh
+++ b/counties-54-west-virginia.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/54/n out/54/s
 
-curl -Rs -o tmp/west-virginia.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/west-virginia.osm.pbf
+curl -Rs -o tmp/west-virginia.osm.pbf -L http://download.geofabrik.de/north-america/us/west-virginia-latest.osm.pbf
 
 osmosis --rb tmp/west-virginia.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-55-wisconsin.sh
+++ b/counties-55-wisconsin.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/55/n out/55/c out/55/s
 
-curl -Rs -o tmp/wisconsin.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/wisconsin.osm.pbf
+curl -Rs -o tmp/wisconsin.osm.pbf -L http://download.geofabrik.de/north-america/us/wisconsin-latest.osm.pbf
 
 osmosis --rb tmp/wisconsin.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \

--- a/counties-56-wyoming.sh
+++ b/counties-56-wyoming.sh
@@ -3,7 +3,7 @@
 mkdir -p tmp
 mkdir -p out/56/w out/56/wc out/56/ec out/56/e
 
-curl -Rs -o tmp/wyoming.osm.pbf -L http://download.geofabrik.de/osm/north-america/us/wyoming.osm.pbf
+curl -Rs -o tmp/wyoming.osm.pbf -L http://download.geofabrik.de/north-america/us/wyoming-latest.osm.pbf
 
 osmosis --rb tmp/wyoming.osm.pbf \
     --tf accept-ways "highway=motorway,motorway_link,trunk,trunk_link,primary,primary_link,secondary,secondary_link,tertiary,tertiary_link,residential,unclassified,road,service,minor,footpath,track,footway,steps,pedestrian,path,cycleway" \


### PR DESCRIPTION
I'd think the title says it all. I used a sed command, below, to update the URL which is curl'd down to provide the base planet-osm subset for subsequent processing. Nothing huge, but might save someone some time who uses this in the future.

sed -i -r 's/http:\/\/download.geofabrik.de\/osm\/north-america\/us\/(._).osm.pbf/http:\/\/download.geofabrik.de\/north-america\/us\/\1-latest.osm.pbf/g' counties_sh
